### PR TITLE
Fix broken lambda function

### DIFF
--- a/source/hashtable.py
+++ b/source/hashtable.py
@@ -77,7 +77,7 @@ class HashTable(object):
         index = self._bucket_index(key)
         bucket = self.buckets[index]
         # Check if an entry with the given key exists in that bucket
-        entry = bucket.find(lambda (k, v): k == key)
+        entry = bucket.find(lambda key_value: key_value[0] == key)
         return entry is not None  # True or False
 
     def get(self, key):
@@ -88,7 +88,7 @@ class HashTable(object):
         index = self._bucket_index(key)
         bucket = self.buckets[index]
         # Find the entry with the given key in that bucket, if one exists
-        entry = bucket.find(lambda (k, v): k == key)
+        entry = bucket.find(lambda key_value: key_value[0] == key)
         if entry is not None:  # Found
             # Return the given key's associated value
             assert isinstance(entry, tuple)
@@ -106,7 +106,7 @@ class HashTable(object):
         bucket = self.buckets[index]
         # Find the entry with the given key in that bucket, if one exists
         # Check if an entry with the given key exists in that bucket
-        entry = bucket.find(lambda (k, v): k == key)
+        entry = bucket.find(lambda key_value: key_value[0] == key)
         if entry is not None:  # Found
             # In this case, the given key's value is being updated
             # Remove the old key-value entry from the bucket first
@@ -126,7 +126,7 @@ class HashTable(object):
         index = self._bucket_index(key)
         bucket = self.buckets[index]
         # Find the entry with the given key in that bucket, if one exists
-        entry = bucket.find(lambda (k, v): k == key)
+        entry = bucket.find(lambda key_value: key_value[0] == key)
         if entry is not None:  # Found
             # Remove the key-value entry from the bucket
             bucket.delete(entry)


### PR DESCRIPTION
The lambda is broken because it cannot accept two parameters. Changing it to a single parameter to represent that tuple of key-value pairs fixes the issue. In the check, you also need to make sure to reference data in slot `0` to get the key.