### PR TITLE
Update Module Name

### DIFF
--- a/source/binarytree_test.py
+++ b/source/binarytree_test.py
@@ -1,6 +1,6 @@
 #!python
 
-from binarysearchtree import BinarySearchTree, BinaryTreeNode
+from binarytree import BinarySearchTree, BinaryTreeNode
 import unittest
 
 


### PR DESCRIPTION
In the `binarytree_test.py` file you attempted to import `binarysearchtree` as a module but it looks like you renamed it to `binarytree.py`. This is just a quick rename of the module in the file.