### PR TITLE
fix ValueError to assert input is int first

### DIFF
--- a/source/recursion.py
+++ b/source/recursion.py
@@ -4,7 +4,7 @@ def factorial(n):
     """factorial(n) returns the product of the integers 1 through n for n >= 0,
     otherwise raises ValueError for n < 0 or non-integer n"""
     # check if n is negative or not an integer (invalid input)
-    if n < 0 or not isinstance(n, int):
+    if not isinstance(n, int) or n < 0:
         raise ValueError('factorial is undefined for n = {}'.format(n))
     # implement factorial_iterative and factorial_recursive below, then
     # change this to call your implementation to verify it passes all tests


### PR DESCRIPTION
Fixing bug where if input is not an int it will crash and not be safely caught. Now the function checks for int value first.